### PR TITLE
fix: PEP 668 環境向けに venv ベースのインストールへ変更

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 __pycache__/
 *.pyc
 .DS_Store
+.venv/

--- a/README.md
+++ b/README.md
@@ -19,19 +19,24 @@ scripts/install.sh セットアップスクリプト
 
 ## セットアップ (Raspberry Pi)
 
+事前に `python3-venv` が必要です (Bookworm 以降は PEP 668 によりシステム pip が拒否されるため、本リポジトリは venv 前提)。
+
 ```bash
+sudo apt install -y python3-venv
 cp .env.example .env
 $EDITOR .env                 # ROOM_ID と STAYWATCH_API_KEY を設定
-./scripts/install.sh         # pip install + systemd unit 配置 + timer 起動
+./scripts/install.sh         # .venv 作成 + 依存 install + systemd unit 配置 + timer 起動
 ```
+
+`install.sh` は実行時のリポジトリ絶対パスを systemd unit にテンプレート展開 (`__REPO_DIR__`) するため、`/home/pi` 以外のユーザでも動作します。
 
 ## 手動操作
 
 ```bash
-python -m stay_watch init    # DB 初期化
-python -m stay_watch scan    # 1 回スキャン
-python -m stay_watch post    # 集計 + POST + DB クリア
-python -m stay_watch clear   # DB のみクリア
+.venv/bin/python -m stay_watch init    # DB 初期化
+.venv/bin/python -m stay_watch scan    # 1 回スキャン
+.venv/bin/python -m stay_watch post    # 集計 + POST + DB クリア
+.venv/bin/python -m stay_watch clear   # DB のみクリア
 ```
 
 ## systemd 操作 (Makefile)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+VENV_DIR="$REPO_DIR/.venv"
 SYSTEMD_DIR=/etc/systemd/system
 UNITS=(
     stay-watch-scan.service
@@ -10,11 +11,17 @@ UNITS=(
     stay-watch-post.timer
 )
 
-sudo pip3 install -r "$REPO_DIR/requirements.txt"
+if [[ ! -d "$VENV_DIR" ]]; then
+    python3 -m venv "$VENV_DIR"
+fi
+
+"$VENV_DIR/bin/pip" install --upgrade pip
+"$VENV_DIR/bin/pip" install -r "$REPO_DIR/requirements.txt"
 
 for unit in "${UNITS[@]}"; do
-    sudo install -m 644 -o root -g root \
-        "$REPO_DIR/systemd/$unit" "$SYSTEMD_DIR/$unit"
+    sed "s|__REPO_DIR__|$REPO_DIR|g" "$REPO_DIR/systemd/$unit" \
+        | sudo tee "$SYSTEMD_DIR/$unit" > /dev/null
+    sudo chmod 644 "$SYSTEMD_DIR/$unit"
 done
 
 sudo systemctl daemon-reload

--- a/systemd/stay-watch-post.service
+++ b/systemd/stay-watch-post.service
@@ -1,13 +1,13 @@
 [Unit]
 Description=stay-watch send aggregated data to server (one-shot)
-ConditionPathExists=/home/pi/stay-watch-reciever
+ConditionPathExists=__REPO_DIR__
 After=network-online.target
 Wants=network-online.target
 
 [Service]
 Type=oneshot
-WorkingDirectory=/home/pi/stay-watch-reciever
-EnvironmentFile=/home/pi/stay-watch-reciever/.env
-ExecStart=/usr/bin/python3 -m stay_watch post
+WorkingDirectory=__REPO_DIR__
+EnvironmentFile=__REPO_DIR__/.env
+ExecStart=__REPO_DIR__/.venv/bin/python -m stay_watch post
 ExecStartPost=-/usr/bin/hciconfig hci0 down
 ExecStartPost=-/usr/bin/hciconfig hci0 up

--- a/systemd/stay-watch-scan.service
+++ b/systemd/stay-watch-scan.service
@@ -1,12 +1,12 @@
 [Unit]
 Description=stay-watch BLE scan (one-shot)
-ConditionPathExists=/home/pi/stay-watch-reciever
+ConditionPathExists=__REPO_DIR__
 After=bluetooth.service
 Requires=bluetooth.service
 
 [Service]
 Type=oneshot
-WorkingDirectory=/home/pi/stay-watch-reciever
-EnvironmentFile=/home/pi/stay-watch-reciever/.env
-ExecStartPre=/usr/bin/python3 -m stay_watch init
-ExecStart=/usr/bin/python3 -m stay_watch scan -t 60
+WorkingDirectory=__REPO_DIR__
+EnvironmentFile=__REPO_DIR__/.env
+ExecStartPre=__REPO_DIR__/.venv/bin/python -m stay_watch init
+ExecStart=__REPO_DIR__/.venv/bin/python -m stay_watch scan -t 60


### PR DESCRIPTION
Bookworm 以降のシステム pip が拒否される問題に対応。あわせて systemd unit の リポジトリパスをテンプレート化し /home/pi 以外のユーザでも動くようにした。

- scripts/install.sh: .venv を作成し pip は venv 内で実行
- systemd/*.service: __REPO_DIR__ プレースホルダ + venv の python を ExecStart に
- install.sh で sed 置換しながら /etc/systemd/system へ配置
- .gitignore に .venv/ 追加
- README にセットアップ前提と venv 経由の手動実行コマンドを追記